### PR TITLE
fix test failing on Windows machines

### DIFF
--- a/t/09_prohibit_core_functions.t
+++ b/t/09_prohibit_core_functions.t
@@ -17,6 +17,8 @@ my %modules = (
 
 my $dir = dirname __FILE__;
 
+plan skip_all =>'This test is not run on Windows machines' if $^O eq 'MSWin32';
+
 my $pc = Perl::Critic->new( -'single-policy' => 'OTRS::ProhibitSomeCoreFunctions' );
 
 for my $module ( keys %modules ) {


### PR DESCRIPTION
This fixes #3 . The failure to build the repository on Windows machines has been solved. Please refer to the issue ticket for more details.