### PR TITLE
Move name and abstract into pod for kwalitee

### DIFF
--- a/lib/Perl/Critic/OTRS.pm
+++ b/lib/Perl/Critic/OTRS.pm
@@ -3,9 +3,13 @@ package Perl::Critic::OTRS;
 use warnings;
 use strict;
 
-# ABSTRACT: A collection of handy Perl::Critic policies
-
 our $VERSION = '0.07';
+
+=pod
+
+=head1 NAME
+
+Perl::Critic::OTRS - A collection of handy Perl::Critic policies
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
I've been assigned Perl::Critic::OTRS as part of the [CPAN PR Challenge](http://cpan-prc.org/) for this month. Thanks for participating!

There are some issues listed on [CPANTS](https://cpants.cpanauthors.org/release/RENEEB/Perl-Critic-OTRS-0.07) and this PR addresses has_abstract_in_pod. This may also be enough to have the pod show by default on MetaCPAN which it doesn't currently seem to do.

If there are other things you would like to have worked on please leave a comment otherwise I'll carry on with the other CPANTS issues.
 