### PR TITLE
Add minimum perl version

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,3 +19,4 @@ repository.type = git
 [Prereqs]
 Perl::Critic = 1.105
 Readonly = 1.03
+[MinimumPerl]


### PR DESCRIPTION
The dist.ini file is updated here to use [MinimumPerl] which auto-detects 5.006 as the minimum version and declares that when building the Makefile.PL

This PR is submitted as part of the [CPAN PR Challenge](http://cpan-prc.org/) for this month. Thanks for participating!