### PR TITLE
Add provided packages to meta data

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,8 @@ repository.url = http://github.com/reneeb/Perl-Critic-OTRS.git
 repository.web = http://github.com/reneeb/Perl-Critic-OTRS
 repository.type = git
 
+[MetaProvides::Package]
+
 [Prereqs]
 Perl::Critic = 1.105
 Readonly = 1.03


### PR DESCRIPTION
The dist.ini file is updated here to use [MetaProvides::Package] which adds the list of the provided packages to the meta data.

This PR is submitted as part of the [CPAN PR Challenge](http://cpan-prc.org/) for this month. Thanks for participating!